### PR TITLE
Add missing InventoryLevel service

### DIFF
--- a/data/mocks/lists/InventoryLevelsList.json
+++ b/data/mocks/lists/InventoryLevelsList.json
@@ -1,0 +1,16 @@
+{
+  "inventory_levels": [
+    {
+      "inventory_item_id": 2084329160713,
+      "location_id": 106790921,
+      "available": 1,
+      "updated_at": "2018-02-20T03:37:40-05:00"
+    },
+    {
+      "inventory_item_id": 2197022867465,
+      "location_id": 106790921,
+      "available": 0,
+      "updated_at": "2018-03-29T05:08:20-04:00"
+    }
+  ]
+}

--- a/lib/Enum/Fields/InventoryLevelFields.php
+++ b/lib/Enum/Fields/InventoryLevelFields.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Shopify\Enum\Fields;
+
+class InventoryLevelFields extends AbstractObjectEnum
+{
+    const INVENTORY_ITEM_ID = 'inventory_item_id';
+    const LOCATION_ID = 'location_id';
+    const AVAILABLE = 'available';
+    const UPDATED_AT = 'updated_at';
+
+    public function getFieldTypes()
+    {
+        return array(
+            'inventory_item_id' => 'integer',
+            'location_id' => 'integer',
+            'available' => 'integer',
+            'updated_at' => 'DateTime',
+        );
+    }
+}

--- a/lib/Enum/Fields/ProductVariantFields.php
+++ b/lib/Enum/Fields/ProductVariantFields.php
@@ -30,6 +30,7 @@ class ProductVariantFields extends AbstractObjectEnum
     const UPDATED_AT = 'updated_at';
     const WEIGHT = 'weight';
     const WEIGHT_UNIT = 'weight_unit';
+    const INVENTORY_ITEM_ID = 'inventory_item_id';
 
     public function getFieldTypes()
     {
@@ -59,7 +60,8 @@ class ProductVariantFields extends AbstractObjectEnum
             'title' => 'string',
             'updated_at' => 'DateTime',
             'weight' => 'string',
-            'weight_unit' => 'string'
+            'weight_unit' => 'string',
+            'inventory_item_id' => 'integer',
         );
     }
 }

--- a/lib/Object/InventoryLevel.php
+++ b/lib/Object/InventoryLevel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Shopify\Object;
+
+use Shopify\Enum\Fields\InventoryLevelFields;
+
+class InventoryLevel extends AbstractObject
+{
+    public static function getFieldsEnum()
+    {
+        return InventoryLevelFields::getInstance();
+    }
+}

--- a/lib/Service/InventoryLevelService.php
+++ b/lib/Service/InventoryLevelService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Shopify\Service;
+
+use Shopify\Object\InventoryLevel;
+
+class InventoryLevelService extends AbstractService
+{
+    /**
+     * Retrieves a list of inventory levels.
+     * You must include inventory_item_ids and/or location_ids as filter params.
+     *
+     * @link   https://help.shopify.com/api/reference/inventorylevel#index
+     * @param  array $params
+     * @return InventoryLevel[]
+     */
+    public function all(array $params)
+    {
+        $endpoint = '/admin/inventory_levels.json';
+        $response = $this->request($endpoint, 'GET', $params);
+
+        return $this->createCollection(InventoryLevel::class, $response['inventory_levels']);
+    }
+}

--- a/test/Service/InventoryLevelServiceTest.php
+++ b/test/Service/InventoryLevelServiceTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Shopify\Test\Service;
+
+use Shopify\Object\InventoryLevel;
+use Shopify\Service\InventoryLevelService;
+use Shopify\Test\TestCase;
+
+class InventoryLevelServiceTest extends TestCase
+{
+    public function testList()
+    {
+        $api = $this->getApiMock('lists/InventoryLevelsList.json');
+        $service = new InventoryLevelService($api);
+        $inventoryLevels = $service->all(array('inventory_item_ids' => '2084329160713,2197022867465'));
+        $this->assertContainsOnlyInstancesOf(
+            InventoryLevel::class,
+            $inventoryLevels
+        );
+    }
+}


### PR DESCRIPTION
Added a new InventoryLevel endpoint. Its a new recommended way to retrieve variants availability informations. The old inventory_quantity field is depreciated and will be removed from api.
