### PR TITLE
Add location_id field to FulfillmentFields

### DIFF
--- a/src/Enum/Fields/FulfillmentFields.php
+++ b/src/Enum/Fields/FulfillmentFields.php
@@ -14,6 +14,7 @@ class FulfillmentFields extends AbstractObjectEnum
     const TRACKING_COMPANY = 'tracking_company';
     const TRACKING_NUMBERS = 'tracking_numbers';
     const TRACKING_URLS = 'tracking_urls';
+    const LOCATION_ID = 'location_id';
     const UPDATED_AT = 'updated_at';
     const VARIANT_INVENTORY_MANAGEMENT = 'variant_inventory_management';
 
@@ -30,6 +31,7 @@ class FulfillmentFields extends AbstractObjectEnum
             'tracking_company' => 'string',
             'tracking_numbers' => 'array',
             'tracking_urls' => 'array',
+            'location_id' => 'integer',
             'updated_at' => 'DateTime',
             'variant_inventory_management' => 'string'
         );


### PR DESCRIPTION
Fix `400 Bad Request` when making a call to create fulfillment endpoint because of the absence of location_id field.