### PR TITLE
FIX: when request full url, make the url itself query string valid

### DIFF
--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -79,10 +79,12 @@ abstract class AbstractService
     public function send(Request $request, array $params = array())
     {
         $args = array();
-        if ($request->getMethod() === 'GET') {
-            $args['query'] = $params;
-        } else {
-            $args['json'] = $params;
+        if (!empty($params)) {
+            if ($request->getMethod() === 'GET') {
+                $args['query'] = $params;
+            } else {
+                $args['json'] = $params;
+            }
         }
         $this->lastResponse = $this->client->send($request, $args);
         return json_decode(


### PR DESCRIPTION
###  I want to use a full link(with query string) send request

`$client->send($request, [ 'query' => [] ]);`

When using GuzzleHttp/Client as the client, this code will remove the query string on my original link

