### PR TITLE
add  AbstractService method: getResponsePaginationLinks

### DIFF
--- a/src/Object/PaginationLink.php
+++ b/src/Object/PaginationLink.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Shopify\Object;
+
+class PaginationLink
+{
+    public $previous;
+
+    public $next;
+
+    public function __construct(string $linkHeader)
+    {
+        if (empty($linkHeader)) {
+            return;
+        }
+
+        foreach (explode(',', $linkHeader) as $item) {
+            if (preg_match('/<([\s\S]+?)>; rel=\"(next|previous)\"/', $item, $match)) {
+                $this->{$match[2]} = $match[1];
+            }
+        }
+    }
+}

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -106,4 +106,21 @@ abstract class AbstractService
             }, $data
         );
     }
+
+    /** [fetch links(next|previous) from Shopify Link headers]
+     *  supported only in api version 2019-07 of the API and above
+     * @return array
+     */
+    public function getResponsePaginationLinks(): array
+    {
+        $links = ['next' => '', 'previous' => ''];
+        if ($linkHeader = $this->getLastResponse()->getHeaderLine('Link')) {
+            foreach (explode(',', $linkHeader) as $item) {
+                if (preg_match('/<([\s\S]+?)>; rel=\"(next|previous)\"/', $item, $match)) {
+                    $links[$match[2]] = $match[1];
+                }
+            }
+        }
+        return $links;
+    }
 }

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Shopify\ApiInterface;
+use Shopify\Object\PaginationLink;
 
 abstract class AbstractService
 {
@@ -107,20 +108,12 @@ abstract class AbstractService
         );
     }
 
-    /** [fetch links(next|previous) from Shopify Link headers]
+    /** [fetch pagination link from Shopify Link headers]
      *  supported only in api version 2019-07 of the API and above
-     * @return array
+     * @return PaginationLink
      */
-    public function getResponsePaginationLinks(): array
+    public function getPaginationLink(): PaginationLink
     {
-        $links = ['next' => '', 'previous' => ''];
-        if ($linkHeader = $this->getLastResponse()->getHeaderLine('Link')) {
-            foreach (explode(',', $linkHeader) as $item) {
-                if (preg_match('/<([\s\S]+?)>; rel=\"(next|previous)\"/', $item, $match)) {
-                    $links[$match[2]] = $match[1];
-                }
-            }
-        }
-        return $links;
+        return new PaginationLink($this->getLastResponse()->getHeaderLine('Link'));
     }
 }

--- a/test/Service/PaginationLinkTest.php
+++ b/test/Service/PaginationLinkTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Shopify\Test\Service;
+
+use Shopify\Object\PaginationLink;
+use Shopify\Service\CustomerService;
+use Shopify\Test\TestCase;
+
+class PaginationLinkTest extends TestCase
+{
+    public function testGetPaginationLink()
+    {
+        $previous = 'https://demo.myshopify.com/admin/api/2021-01/customers.json?limit=5&page_info=xyzprevious';
+        $next = 'https://demo.myshopify.com/admin/api/2021-01/customers.json?limit=5&page_info=xyznext';
+
+        // test previous && next
+        $api = $this->getApiMock(
+            ['customers' => ['unit test']],
+            ['Link' => '<' . $previous . '>; rel="previous", <' . $next . '>; rel="next"']
+        );
+
+        $service = new CustomerService($api);
+        $service->all();
+        $res = $service->getPaginationLink();
+        $this->assertInstanceOf(PaginationLink::class, $res);
+        $this->assertTrue($res->next == $next);
+        $this->assertTrue($res->previous == $previous);
+
+        // test only next
+        $api = $this->getApiMock(
+            ['customers' => ['unit test']],
+            ['Link' => '<' . $next . '>; rel="next"']
+        );
+
+        $service = new CustomerService($api);
+        $service->all();
+        $res = $service->getPaginationLink();
+        $this->assertInstanceOf(PaginationLink::class, $res);
+        $this->assertTrue($res->next == $next);
+    }
+}

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -20,7 +20,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         return $api;
     }
 
-    public function getApiMock($file)
+    public function getApiMock($file, array $headers = ['X-Foo' => 'Bar'])
     {
         $json = null;
         if (is_array($file)) {
@@ -33,7 +33,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
             }
             $json = file_get_contents($path);
         }
-        $mock = new MockHandler([new Response(200, ['X-Foo' => 'Bar'], $json)]);
+        $mock = new MockHandler([new Response(200, $headers, $json)]);
 
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);


### PR DESCRIPTION

shopify use Cursor-based pagination in api version 2019-07 and above.
so, add method getResponsePaginationLinks to fetch links(next|previous) from Shopify Link headers.

~ Thank you for the package.
