### PR TITLE
Solve the problem that there is no Shopify version number in the request URL, resulting in 404

### DIFF
--- a/src/PrivateApi.php
+++ b/src/PrivateApi.php
@@ -29,7 +29,7 @@ class PrivateApi extends AbstractApi
     {
         $args = array(
             'base_uri' => sprintf(
-                "https://%s/admin/api/%s",
+                "https://%s/admin/api/%s/",
                 $this->myshopify_domain,
                 $this->getApiVersion()
             ),


### PR DESCRIPTION
Solve the problem that there is no Shopify version number in the request URL, resulting in 404